### PR TITLE
generate: Drop devices and mounts

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -619,32 +619,7 @@ func getDefaultTemplate() specs.LinuxSpec {
 				Cwd: "/",
 			},
 			Hostname: "shell",
-			Mounts: []specs.Mount{
-				{
-					Destination: "/proc",
-					Type:        "proc",
-					Source:      "proc",
-					Options:     nil,
-				},
-				{
-					Destination: "/dev/pts",
-					Type:        "devpts",
-					Source:      "devpts",
-					Options:     []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=5"},
-				},
-				{
-					Destination: "/dev/shm",
-					Type:        "tmpfs",
-					Source:      "shm",
-					Options:     []string{"nosuid", "noexec", "nodev", "mode=1777", "size=65536k"},
-				},
-				{
-					Destination: "/sys",
-					Type:        "sysfs",
-					Source:      "sysfs",
-					Options:     []string{"nosuid", "noexec", "nodev"},
-				},
-			},
+			Mounts: []specs.Mount{},
 		},
 		Linux: specs.Linux{
 			Capabilities: []string{
@@ -687,44 +662,7 @@ func getDefaultTemplate() specs.LinuxSpec {
 					Soft: uint64(1024),
 				},
 			},
-			Devices: []specs.Device{
-				{
-					Type:  'c',
-					Path:  "/dev/null",
-					Major: 1,
-					Minor: 3,
-				},
-				{
-					Type:  'c',
-					Path:  "/dev/random",
-					Major: 1,
-					Minor: 8,
-				},
-				{
-					Type:  'c',
-					Path:  "/dev/full",
-					Major: 1,
-					Minor: 7,
-				},
-				{
-					Type:  'c',
-					Path:  "/dev/tty",
-					Major: 5,
-					Minor: 0,
-				},
-				{
-					Type:  'c',
-					Path:  "/dev/zero",
-					Major: 1,
-					Minor: 5,
-				},
-				{
-					Type:  'c',
-					Path:  "/dev/urandom",
-					Major: 1,
-					Minor: 9,
-				},
-			},
+			Devices: []specs.Device{},
 		},
 	}
 


### PR DESCRIPTION
Cross-posted from mrunalp/ocitools#15.

Most of these are covered by the requirements that landed in
opencontainers/specs#164, and I don't think the additional mqueue
mount is worth the space between the spec requirements and the
ocitools-generated configs.  More details in the commit messages.

There was some [discussion in the 2016-01-20 meeting][1] about the
meaning of lists that didn't include default entries, but I think
we're all on the same page that unset values mean “give me the
defaults”.  So this should be mergable without waiting for that
discussion to reach consensus.

[1]: http://ircbot.wl.linuxfoundation.org/meetings/opencontainers/2016/opencontainers.2016-01-20-18.02.log.html#l-43