### PR TITLE
Use bash for get-stage3.sh

### DIFF
--- a/get-stage3.sh
+++ b/get-stage3.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Download the current Gentoo stage3
 #


### PR DESCRIPTION
I got the following error with `make rootfs.tar.gz`:
./get-stage3.sh: 43: ./get-stage3.sh: Bad substitution

Change to bash fixed it.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>