### PR TITLE
get-stage3.sh: Replace non-POSIX `${FILE/${DATE}/current}` with sed

### DIFF
--- a/get-stage3.sh
+++ b/get-stage3.sh
@@ -40,7 +40,7 @@ for FILE in "${STAGE3}" "${STAGE3_CONTENTS}" "${STAGE3_DIGESTS}"; do
 		fi
 	fi
 
-	CURRENT="${FILE/${DATE}/current}"
+	CURRENT=$(echo "${FILE}" | sed "s/${DATE}/current/")
 	(
 		cd downloads &&
 		rm -f "${CURRENT}" &&


### PR DESCRIPTION
`${parameter/pattern/string}` [isn't in POSIX 2013][1], which leads to:

    43: ./get-stage3.sh: Bad substitution

when folks run a strictly-POSIX shell.  Replace it with [command
substitution][2] invoking [echo][3] and [sed][4].

An alternative to #5.

[1]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_02
[2]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_03
[3]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html
[4]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/sed.html