### PR TITLE
Add make test for Makefile and use make test to fix problems.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,17 @@ downloads/stage3-amd64-current.tar.bz2: get-stage3.sh
 clean:
 	rm -f ocitools runtimetest downloads/*
 	sudo rm -rf rootfs
+
+.PHONY: test .gofmt .govet .golint
+
+test: .gofmt .govet .golint
+
+.gofmt:
+	go fmt ./...
+
+.govet:
+	go vet -x ./...
+
+.golint:
+	golint ./...
+

--- a/cmd/runtimetest/main.go
+++ b/cmd/runtimetest/main.go
@@ -144,7 +144,7 @@ func validateCapabilities(spec *specs.LinuxSpec, rspec *specs.LinuxRuntimeSpec) 
 		if expectedSet != actuallySet {
 			if expectedSet {
 				return fmt.Errorf("Expected Capability %v not set for process", cap.String())
-			} 
+			}
 			return fmt.Errorf("Unexpected Capability %v set for process", cap.String())
 		}
 	}


### PR DESCRIPTION
Users can use make test to check gofmt/govet/golint errors.

Signed-off-by: ChengTiesheng <chengtiesheng@huawei.com>