### PR TITLE
Pass uuid to runc start per spec to make runtime tests work again

### DIFF
--- a/test_runtime.sh
+++ b/test_runtime.sh
@@ -68,7 +68,7 @@ pushd $TESTDIR > /dev/null
 ocitools generate --args /runtimetest --rootfs ""
 popd > /dev/null
 
-TESTCMD="${RUNTIME} start"
+TESTCMD="${RUNTIME} start $(uuidgen)"
 pushd $TESTDIR > /dev/null
 if ! ${TESTCMD}; then
 	error "Runtime ${RUNTIME} failed validation"


### PR DESCRIPTION
Signed-off-by: Mrunal Patel <mrunalp@gmail.com>