### PR TITLE
man/ocitools-generate: Use [OPTIONS] in the synopsis

### DIFF
--- a/man/ocitools-generate.1.md
+++ b/man/ocitools-generate.1.md
@@ -5,43 +5,7 @@
 ocitools-generate - Generate a config.json for an OCI container
 
 # SYNOPSIS
-**ocitools generate**
-[**--arch**[=*[]*]
-[**--apparmor**[=*[]*]]
-[**--args**[=*[]*]]
-[**--bind**[=*[]*]]
-[**--cap-add**[=*[]*]]
-[**--cap-drop**[=*[]*]]
-[**--cwd**[=*[]*]]
-[**--env**[=*[]*]]
-[**--gid**[=*GID*]]
-[**--gidmappings**[=*[]*]]]
-[**--groups**[=*[]*]]
-[**--hostname**[=*[]*]]
-[**--help**]
-[**--ipc**]
-[**--network**]
-[**--no-new-privileges**]
-[**--mount**]
-[**--mount-cgroups**]
-[**--os**[=*[]*]]
-[**--pid**]
-[**--poststart**[=*[]*]]
-[**--poststop**[=*[]*]]
-[**--prestart**[=*[]*]]
-[**--privileged**]
-[**--read-only**]
-[**--root-propagation**[=*[]*]]
-[**--rootfs**[=*[]*]]
-[**--seccomp-default**[=*[]*]]
-[**--seccomp-arch**[=*[]*]]
-[**--seccomp-syscalls**[=*[]*]]
-[**--selinux-label**[=*[]*]]
-[**--sysctl**[=*[]*]]
-[**--tmpfs**[=*[]*]]
-[**--uid**[=*[]*]]
-[**--uidmappings**[=*[]*]]
-[**--uts**]
+**ocitools generate** *[OPTIONS]*
 
 # DESCRIPTION
 **ocitools generate** is used to generate a config.json (OCI spec file) to be used to


### PR DESCRIPTION
There are so many of these, I think it's time to follow grep(1) and
friends and punt the individual details to the OPTIONS section.

I stared off trying to adjust the metavars (to use the [Python
nomenclature][1]) to match the OPTIONS section, but there are so many
;).  And useful metavars in the synopsis would make the synopsis even
more unwieldy than it already was.

[1]: https://docs.python.org/3/library/argparse.html#metavar