### PR TITLE
CONTRIBUTING: Document Signed-off-by and the DCO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Sign your work
+
+The sign-off is a simple line at the end of the explanation for the patch, which certifies that you wrote it or otherwise have the right to pass it on as an open-source patch.
+The rules are pretty simple: if you can certify the below (from [developercertificate.org](http://developercertificate.org/)):
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+then you just add a line to every git commit message:
+
+    Signed-off-by: Joe Smith <joe@gmail.com>
+
+using your real name (sorry, no pseudonyms or anonymous contributions.)
+
+You can add the sign off when creating the git commit via `git commit -s`.


### PR DESCRIPTION
This project seems to have been operating under the assumption that
the usual `Signed-off-by` ↔ DCO mapping applied.  But it's nice to
make that explicit.  This commit copies the current DCO section from
runtime-spec, but puts it in `CONTRIBUTING.md` for [a more native GitHub
experience][1].

Looking through the history of the repo, the only non-merge commits
without sign-offs are by Mrunal:

* 5286bb06 (Update runtime validation section, 2016-01-19)
* b71f0452 (Update README.md, 2015-11-09)
* 2c0e9e20 (Update help for generate, 2015-11-05)
* 850abe9f (Update README.md, 2015-09-15)
* bb903899 (Initial commit, 2015-09-15)

who clearly doesn't have a problem signing for the rest of his work
and is unlikely to have stolen those contributions from somewhere else
;).

[1]: https://github.com/blog/1184-contributing-guidelines