### PR TITLE
man/ocitools-generate: Document --template

### DIFF
--- a/man/ocitools-generate.1.md
+++ b/man/ocitools-generate.1.md
@@ -191,6 +191,10 @@ inside of the container.
   Add sysctl settings e.g net.ipv4.forward=1, only allowed if the syctl is
   namespaced.
 
+**--template**=PATH
+  Override the default template with your own.
+  Additional options will only adjust the relevant portions of your template.
+
 **--tmpfs**=[] Create a tmpfs mount
   Mount a temporary filesystem (`tmpfs`) mount into a container, for example:
 


### PR DESCRIPTION
Which landed in a937f7a4 (Add support for using a base template,
2016-04-13, #35) and [still needs docs][1].

This PR builds on #42 and #44, so they should land first.  I'm happy
to rebase this commit on top of master as those PRs land, or it can
land with the merges I currently have in the branch.

[1]: https://github.com/opencontainers/ocitools/pull/35#issuecomment-210191802