### PR TITLE
generate: Change --mount-cgroups default to 'no'

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -37,7 +37,7 @@ var generateFlags = []cli.Flag{
 	cli.StringSliceFlag{Name: "tmpfs", Usage: "mount tmpfs"},
 	cli.StringSliceFlag{Name: "args", Usage: "command to run in the container"},
 	cli.StringSliceFlag{Name: "env", Usage: "add environment variable"},
-	cli.StringFlag{Name: "mount-cgroups", Value: "ro", Usage: "mount cgroups (rw,ro,no)"},
+	cli.StringFlag{Name: "mount-cgroups", Value: "no", Usage: "mount cgroups (rw,ro,no)"},
 	cli.StringSliceFlag{Name: "bind", Usage: "bind mount directories src:dest:(rw,ro)"},
 	cli.StringSliceFlag{Name: "prestart", Usage: "path to prestart hooks"},
 	cli.StringSliceFlag{Name: "poststart", Usage: "path to poststart hooks"},

--- a/man/ocitools-generate.1.md
+++ b/man/ocitools-generate.1.md
@@ -121,8 +121,8 @@ inside of the container.
 **--mount**
   Use a mount namespace
 
-**--mount-cgroups**
-  Mount cgroups (rw,ro,no)
+**--mount-cgroups**=[rw|ro|no]
+  Mount cgroups.  The default is `no`.
 
 **--os**=OS
   Operating system used within the container


### PR DESCRIPTION
Since a937f7a4 (Add support for using a base template, 2016-04-13,
`--mount-cgroups` is not `no`, that will lead to additional cgroup
entries in the mount array (even if there was already a cgroup entry
in the mount array).  Instead of writing logic to find and clobber
existing cgroup entries, just make the default the no-op setting.