### PR TITLE
generate: Set ociVersion if it wasn't set in the template

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -123,6 +123,9 @@ func loadTemplate(path string) (spec *rspec.Spec, err error) {
 }
 
 func modify(spec *rspec.Spec, context *cli.Context) error {
+	if len(spec.Version) == 0 {
+		spec.Version = rspec.Version
+	}
 	spec.Root.Path = context.String("rootfs")
 	if context.IsSet("read-only") {
 		spec.Root.Readonly = context.Bool("read-only")


### PR DESCRIPTION
The default template has this information already, but user-supplied
templates may not.  Before this commit:

    $ ocitools generate --template <(echo '{}')
    $ head -n2 config.json
    {
      "ociVersion": "",

And after this commit, the last line is:

      "ociVersion": "0.6.0-dev",

Regardless of this commit, template authors can set whatever version
they like without getting clobbered:

    $ ocitools generate --template <(echo '{"ociVersion": "xyz"}')
    $ head -n2 config.json
    {
      "ociVersion": "xyz",