### PR TITLE
generate: Set process.args to an empty array if it was nil

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -130,6 +130,9 @@ func modify(spec *rspec.Spec, context *cli.Context) error {
 	spec.Hostname = context.String("hostname")
 	spec.Process.User.UID = uint32(context.Int("uid"))
 	spec.Process.User.GID = uint32(context.Int("gid"))
+	if spec.Process.Args == nil {
+		spec.Process.Args = make([]string, 0)
+	}
 	spec.Process.SelinuxLabel = context.String("selinux-label")
 	spec.Linux.MountLabel = context.String("mount-label")
 	spec.Platform.OS = context.String("os")


### PR DESCRIPTION
Before this commit:

    $ ocitools generate --template <(echo '{}')
    $ grep args config.json
        "args": null,

With this commit:

    $ grep args config.json
        "args": [],

That's still not a particularly useful value for the process
arguments, but it complies with the specs [“array of strings”
typing][1] (opencontainers/runtime-spec#416) and is closer to a
the useful entry (a non-empty array).

[1]: https://github.com/opencontainers/runtime-spec/blob/dbce512cec0cd0774b236980ec18a4f6a91bc77e/config.md#process-configuration