### PR TITLE
man/ocitools-generate: Reword --poststop (after container-process exit)

### DIFF
--- a/man/ocitools-generate.1.md
+++ b/man/ocitools-generate.1.md
@@ -120,8 +120,8 @@ inside of the container.
   main process has been created.
 
 **--poststop**=CMD
-  Path to command to run in poststop hooks. This command will be run after the
-  container completes but before the container process is destroyed
+  Path to command to run in poststop hooks. The command will be run
+  after the container process is stopped.
 
 **--prestart**=CMD
   Path to command to run in prestart hooks. This command will be run before


### PR DESCRIPTION
“is stopped” echoes [the spec][1].  I'd be a bit happier if the spec
used “exits” instead of “is stopped” (to avoid confusion with
SIGSTOP), but this man page is not the place to be generating new
language.

Fixes #41.

[1]: https://github.com/opencontainers/runtime-spec/blob/v0.5.0/config.md#poststop