### PR TITLE
validate: Drop mount checks

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -86,7 +86,6 @@ func bundleValidate(spec rspec.Spec, rootfs string) {
 	checkSemVer(spec.Version)
 	checkPlatform(spec.Platform)
 	checkProcess(spec.Process, rootfs)
-	checkMounts(spec.Mounts, rootfs)
 	checkLinux(spec.Linux, rootfs)
 }
 
@@ -94,17 +93,6 @@ func checkSemVer(version string) {
 	re, _ := regexp.Compile("^(\\d+)?\\.(\\d+)?\\.(\\d+)?$")
 	if ok := re.Match([]byte(version)); !ok {
 		logrus.Fatalf("%q is not a valid version format, please read 'SemVer v2.0.0'", version)
-	}
-}
-
-func checkMounts(mounts []rspec.Mount, rootfs string) {
-	for _, mount := range mounts {
-		destPath := path.Join(rootfs, mount.Destination)
-		if fi, err := os.Stat(destPath); err != nil {
-			logrus.Fatalf("Cannot find the mount destination %q", destPath)
-		} else if !fi.IsDir() {
-			logrus.Fatalf("Mount destination %q is not a directory.", destPath)
-		}
 	}
 }
 


### PR DESCRIPTION
These landed as CheckMounts in 647e3552 (bundle validate update to
0.3.0, 2016-02-23, #20), but both checks are too strict.

The first (destination exists in the rootfs) errors on valid cases
like:

    "mounts": [
      {
        "source": "users",
        "destination": "/home",
        "type": "bind"
      },
      {
        "source": "none",
        "destination": "/home/wking",
        "type": "tmpfs"
      }
    ]

Where the source `users` directory already contained a `wking`
subdirectory.  So by the time the tmpfs was setup, the destination
directory would exist, but at validation time (without having run the
bind mount) the tmpfs destination directory would not exist.

The second (destination is a directory) errors on valid cases like:

    "mounts": [
      {
        "source": "/etc/resolv.conf",
        "destination": "/etc/resolv.conf",
        "type": "bind"
      }
    ]

because binding files to files works.  In a shell:

    # touch test
    # mount --bind /etc/resolv.conf test
    # umount test

However binding directories to files does not work:

    # mount --bind /etc test
    mount: mount point /tmp/test is not a directory

Figuring out which mount configurations are valid and which aren't may
be possible, but I'm pretty sure it's more trouble than we want to get
into.  There may be room for other mount tests (e.g. comparing `type`
against `/proc/filesystems` as a host-specific test), but I'm leaving
those to subsequent pull requests.