### PR TITLE
test_runtime.sh: Drop /testroot (falling back to $TMPDIR)

### DIFF
--- a/test_runtime.sh
+++ b/test_runtime.sh
@@ -46,8 +46,7 @@ if ! command -v ${RUNTIME} > /dev/null; then
 	error "Runtime ${RUNTIME} not found in the path"
 fi
 
-mkdir -p /testroot
-TMPDIR=$(mktemp -p /testroot -d)
+TMPDIR=$(mktemp -d)
 TESTDIR=${TMPDIR}/busybox
 mkdir -p ${TESTDIR}
 


### PR DESCRIPTION
I've never run a system where an unprivileged user could create a new
root directory, so this avoids:

    $ mkdir -p /testroot
    mkdir: cannot create directory ‘/testroot’: Permission denied

I'm not entirely clear why the old code used /testroot.  It landed in
d3e2985 (Add a script to prepare a rootfs for testing, 2015-10-13),
but without additional motivation.  It's possible that it's related to
opencontainers/runc#710, but that was proposed much later
(2016-03-30).  And I'm not sure what the pivot problems were that runC
avoids with --no-pivot, since ccon has no problem pivoting from a
tmpfs:

    $ pwd
    /tmp/pivot-root
    $ grep /tmp /proc/self/mounts
    none /tmp tmpfs rw,relatime 0 0
    $ jq .namespaces.mount.mounts config.json
    [
      {
        "source": "rootfs",
        "target": "rootfs",
        "flags": [
          "MS_BIND"
        ]
      },
      {
        "source": "/dev",
        "target": "rootfs/dev",
        "flags": [
          "MS_BIND",
          "MS_REC"
        ]
      },
      {
        "target": "rootfs/proc",
        "type": "proc"
      },
      {
        "source": "/sys",
        "target": "rootfs/sys",
        "flags": [
          "MS_BIND",
          "MS_REC"
        ]
      },
      {
        "source": "/etc/resolv.conf",
        "target": "rootfs/etc/resolv.conf",
        "flags": [
          "MS_BIND"
        ]
      },
      {
        "source": "rootfs",
        "type": "pivot-root"
      },
      {
        "target": "/",
        "flags": [
          "MS_REMOUNT",
          "MS_RDONLY",
          "MS_BIND"
        ]
      },
      {
        "target": "/run",
        "type": "tmpfs"
      },
      {
        "target": "/tmp",
        "type": "tmpfs"
      }
    ]
    $ strace -o /tmp/trace ccon --verbose
    ...
    mount 0: /tmp/pivot-root/rootfs to /tmp/pivot-root/rootfs (type: (null), flags: 4096, data (null))
    mount 1: /dev to /tmp/pivot-root/rootfs/dev (type: (null), flags: 20480, data (null))
    mount 2: (null) to /tmp/pivot-root/rootfs/proc (type: proc, flags: 0, data (null))
    mount 3: /sys to /tmp/pivot-root/rootfs/sys (type: (null), flags: 20480, data (null))
    mount 4: /etc/resolv.conf to /tmp/pivot-root/rootfs/etc/resolv.conf (type: (null), flags: 4096, data (null))
    pivot root to /tmp/pivot-root/rootfs
    unmount old root from pivot-root.vuQ2sY
    mount 6: (null) to / (type: (null), flags: 4129, data (null))
    mount 7: (null) to /run (type: tmpfs, flags: 0, data (null))
    mount 8: (null) to /tmp (type: tmpfs, flags: 0, data (null))
    ...
    / # exit
    container process 2294 exited with 0
    $ grep -1 pivot_root /tmp/trace
    2294  write(2, "pivot root to /tmp/pivot-root/ro"..., 37) = 37
    2294  pivot_root("/tmp/pivot-root/rootfs", "/tmp/pivot-root/rootfs/pivot-root.lHRFf5") = 0
    2294  chdir("/")                        = 0

Folks that do have a problem with their default TMPDIR can always do
things like:

    # export TMPDIR=/testroot
    # mkdir -p "${TMPDIR}"
    # ./test_runtime.sh