### PR TITLE
Remove non-standard cgroups mount from generated config

### DIFF
--- a/test_runtime.sh
+++ b/test_runtime.sh
@@ -64,7 +64,7 @@ cp runtimetest ${TESTDIR}
 
 
 pushd $TESTDIR > /dev/null
-ocitools generate --args /runtimetest --rootfs ""
+ocitools generate --args /runtimetest --rootfs "" --mount-cgroups=no
 popd > /dev/null
 
 TESTCMD="${RUNTIME} start $(uuidgen)"


### PR DESCRIPTION
Needed for runc runtime validation to pass after #81 

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>