### PR TITLE
.mailmap: Add entries for inconsistent users

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+LinZhinan(Zen Lin) <linzhinan@huawei.com>
+Mrunal Patel <mrunalp@gmail.com> <mrunal@me.com>
+Wang Qilin <wangqilin2@huawei.com> <qilin.wang@huawei.com>
+梁辰晔 (Liang Chenye) <liangchenye@huawei.com>


### PR DESCRIPTION
Where the same user had multiple entries, I mostly went with whichever
entry had the most non-merge commits.  Before this commit:

    $ git shortlog -se --no-merges
        ...
         5  Mrunal Patel <mrunal@me.com>
        81  Mrunal Patel <mrunalp@gmail.com>
        ...
         1  Wang Qilin <qilin.wang@huawei.com>
         5  Wang Qilin <wangqilin2@huawei.com>
         8  liang chenye <liangchenye@huawei.com>
         8  liangchenye <liangchenye@huawei.com>
        ...
         1  梁辰晔 (Liang Chenye) <liangchenye@huawei.com>

With @liangchenye, I went with the version that also included the logograms,
because logograms are cool and it matches his [GitHub name][1] ;).

Details on the format in git-shortlog(1).

Ping @mrunalp, @wangkirin, @liangchenye.

[1]: https://github.com/liangchenye