### PR TITLE
generate: Add --output=PATH and write to stdout by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ ocitools is a collection of tools for working with the [OCI runtime specificatio
 
 ## Generating an OCI runtime spec configuration files
 
-[`ocitools generate`][generate.1] generates a [`config.json`][config.json] for an [OCI bundle][bundle].
-This `config.json` file can be placed into a directory and used by an [OCI compatible runtime][runtime-spec] like [runC][] to run a container.
+[`ocitools generate`][generate.1] generates [configuration JSON][config.json] for an [OCI bundle][bundle].
+[OCI-compatible runtimes][runtime-spec] like [runC][] expect to read the configuration from `config.json`.
 
 ```sh
-$ ocitools generate
+$ ocitools generate --output config.json
 $ cat config.json
 {
         "ociVersion": "0.5.0",

--- a/generate.go
+++ b/generate.go
@@ -16,6 +16,7 @@ import (
 )
 
 var generateFlags = []cli.Flag{
+	cli.StringFlag{Name: "output", Value: "output", Usage: "output file (defaults to stdout)"},
 	cli.StringFlag{Name: "rootfs", Value: "rootfs", Usage: "path to the rootfs"},
 	cli.BoolFlag{Name: "read-only", Usage: "make the container's rootfs read-only"},
 	cli.BoolFlag{Name: "privileged", Usage: "enabled privileged container settings"},
@@ -101,13 +102,20 @@ var generateCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		cName := "config.json"
 		data, err := json.MarshalIndent(&spec, "", "\t")
 		if err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(cName, data, 0666); err != nil {
-			return err
+		if context.IsSet("output") {
+			output := context.String("output")
+			if err := ioutil.WriteFile(output, data, 0666); err != nil {
+				return err
+			}
+		} else {
+			_, err = os.Stdout.Write(data)
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	},

--- a/man/ocitools-generate.1.md
+++ b/man/ocitools-generate.1.md
@@ -9,9 +9,10 @@ ocitools-generate - Generate a config.json for an OCI container
 
 # DESCRIPTION
 
-`ocitools generate` generates a `config.json` for an OCI bundle.  This
-`config.json` file can be placed into a directory and used by an OCI
-compatible runtime like runC to run a container.
+`ocitools generate` generates configuration JSON for an OCI bundle.
+By default, it writes the JSON to stdout, but you can use **--output**
+to direct it to a file.  OCI-compatible runtimes like runC expect to
+read the configuration from `config.json`.
 
 # OPTIONS
 **--apparmor**=PROFILE
@@ -111,6 +112,11 @@ inside of the container.
   will block the container processes from gaining any additional privileges
   using tools like setuid apps.  It is a good idea to run unprivileged
   containers with this flag.
+
+**--output**=PATH
+  Instead of writing the configuration JSON to stdout, write it to a
+  file at *PATH* (overwriting the existing content if a file already
+  exists at *PATH*).
 
 **--os**=OS
   Operating system used within the container

--- a/test_runtime.sh
+++ b/test_runtime.sh
@@ -78,7 +78,7 @@ tar -xf  rootfs.tar.gz -C ${TESTDIR}
 cp runtimetest ${TESTDIR}
 
 pushd $TESTDIR > /dev/null
-ocitools generate "${TEST_ARGS[@]}" --rootfs '.'
+ocitools generate --output config.json "${TEST_ARGS[@]}" --rootfs '.'
 popd > /dev/null
 
 TESTCMD="${RUNTIME} start $(uuidgen)"


### PR DESCRIPTION
This makes it easier to post-process output before writing it to disk.  For example, you may want to make adjustments with jq and/or [write part of the configuration to a different file for consumption by non-OCI tools][1].

[1]: https://github.com/opencontainers/ocitools/pull/128#issuecomment-230580568