### PR TITLE
generate: specs.Linux needed to be a pointer

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -110,7 +110,7 @@ func New() Generator {
 				Options:     []string{"nosuid", "noexec", "nodev", "ro"},
 			},
 		},
-		Linux: rspec.Linux{
+		Linux: &rspec.Linux{
 			Resources: &rspec.Resources{
 				Devices: []rspec.DeviceCgroup{
 					{


### PR DESCRIPTION
```
[09:47:37] <papey_lap> hi, playing with ocitools but go getting github.com/opencontainers/ocitools/generate failed because of :
[09:47:47] <papey_lap> generate.go:140: cannot use specs.Linux literal (type *specs.Linux) as type specs.Linux in field value
[09:50:59] <papey_lap> oops, wrong paste : cannot use specs.Linux literal (type specs.Linux) as type *specs.Linux in field value
```

Reported-by: papey_lap (on IRC)
Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>