### PR TITLE
Check CAP_LAST_CAP while setting privileged

### DIFF
--- a/cmd/ocitools/generate.go
+++ b/cmd/ocitools/generate.go
@@ -78,7 +78,7 @@ var generateCommand = cli.Command{
 			}
 		}
 
-		err := setupSpec(specgen, context)
+		err := setupSpec(&specgen, context)
 		if err != nil {
 			return err
 		}
@@ -96,8 +96,12 @@ var generateCommand = cli.Command{
 	},
 }
 
-func setupSpec(g generate.Generator, context *cli.Context) error {
-	spec := g.GetSpec()
+func setupSpec(g *generate.Generator, context *cli.Context) error {
+	if context.GlobalBool("host-specific") {
+		g.HostSpecific = true
+	}
+
+	spec := g.Spec()
 
 	if len(spec.Version) == 0 {
 		g.SetVersion(rspec.Version)
@@ -369,7 +373,7 @@ func checkNs(nsMaps map[string]string, nsName string) bool {
 	return true
 }
 
-func setupLinuxNamespaces(g generate.Generator, needsNewUser bool, nsMaps map[string]string) {
+func setupLinuxNamespaces(g *generate.Generator, needsNewUser bool, nsMaps map[string]string) {
 	for _, nsName := range generate.Namespaces {
 		if !checkNs(nsMaps, nsName) && !(needsNewUser && nsName == "user") {
 			continue

--- a/cmd/ocitools/main.go
+++ b/cmd/ocitools/main.go
@@ -18,6 +18,10 @@ func main() {
 			Value: "error",
 			Usage: "Log level (panic, fatal, error, warn, info, or debug)",
 		},
+		cli.BoolFlag{
+			Name:  "host-specific",
+			Usage: "generate host-specific configs or do host-specific validations",
+		},
 	}
 
 	app.Commands = []cli.Command{

--- a/cmd/ocitools/validate.go
+++ b/cmd/ocitools/validate.go
@@ -24,7 +24,6 @@ type configCheck func(rspec.Spec, string, bool) []string
 
 var bundleValidateFlags = []cli.Flag{
 	cli.StringFlag{Name: "path", Value: ".", Usage: "path to a bundle"},
-	cli.BoolFlag{Name: "host-specific", Usage: "Check host specific configs."},
 }
 
 var (
@@ -99,7 +98,7 @@ var bundleValidateCommand = cli.Command{
 			return fmt.Errorf("The root path %q is not a directory.", rootfsPath)
 		}
 
-		hostCheck := context.Bool("host-specific")
+		hostCheck := context.GlobalBool("host-specific")
 
 		checks := []configCheck{
 			checkMandatoryFields,

--- a/man/ocitools-validate.1.md
+++ b/man/ocitools-validate.1.md
@@ -18,16 +18,6 @@ Validate an OCI bundle
 **--path=PATH
   Path to bundle
 
-**--host-specific**
-  Check host specific configs.
-  By default, validation only tests for compatibility with a hypothetical host.
-  With this flag, validation will also run more specific tests to see whether
-  the current host is capable of launching a container from the configuration.
-  For example, validating a compliant Windows configuration on a Linux machine
-  will pass without this flag ("there may be a Windows host capable of
-  launching this container"), but will fail with it ("this host is not capable
-  of launching this container").
-
 # SEE ALSO
 **ocitools**(1)
 

--- a/man/ocitools.1.md
+++ b/man/ocitools.1.md
@@ -15,10 +15,25 @@ ocitools is a collection of tools for working with the [OCI runtime specificatio
 
 # OPTIONS
 **--help**
-  Print usage statement
+  Print usage statement.
 
 **-v**, **--version**
   Print version information.
+
+**--log-level**
+  Log level (panic, fatal, error, warn, info, or debug) (default: "error").
+
+**--host-specific**
+  Generate host-specific configs or do host-specific validations.
+
+  By default, generator generates configs without checking whether they are
+  supported on the current host. With this flag, generator will first check
+  whether each config is supported on the current host, and only add it into
+  the config file if it passes the checking.
+
+  By default, validation only tests for compatibility with a hypothetical host.
+  With this flag, validation will also run more specific tests to see whether
+  the current host is capable of launching a container from the configuration.
 
 # COMMANDS
 **validate**


### PR DESCRIPTION
The PR checks whether each cap inside `capability.List()` is <= `capability.CAP_LAST_CAP` before adding it into `finalCapList`.
This avoids add unsupported cap into `finalCapList`. For example, `CAP_AUDIT_READ` is added into  the kernel since Linux 3.16, and not supported on RHEL7.

Signed-off-by: Haiyan Meng <hmeng@redhat.com>