### PR TITLE
test_runtime.sh: Drop pushd/popd from around 'generate'

### DIFF
--- a/test_runtime.sh
+++ b/test_runtime.sh
@@ -77,9 +77,7 @@ trap cleanup EXIT
 tar -xf  rootfs.tar.gz -C ${TESTDIR}
 cp runtimetest ${TESTDIR}
 
-pushd $TESTDIR > /dev/null
-ocitools generate --output config.json "${TEST_ARGS[@]}" --rootfs '.'
-popd > /dev/null
+ocitools generate --output "${TESTDIR}/config.json" "${TEST_ARGS[@]}" --rootfs '.'
 
 TESTCMD="${RUNTIME} start $(uuidgen)"
 pushd $TESTDIR > /dev/null


### PR DESCRIPTION
The switch to `--output` in 06d61a34 (generate: Add `--output=PATH` and write to stdout by default, 2016-07-05, #129) was too narrow.  There's no need to change directories now that the output path is configurable.