### PR TITLE
Makefile: clean up compiled man page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ install: man
 	install -m 644 completions/bash/ocitools $(PREFIX)/share/bash-completion/completions
 
 clean:
-	rm -f ocitools runtimetest
+	rm -f ocitools runtimetest *.1
 
 .PHONY: test .gofmt .govet .golint
 


### PR DESCRIPTION
Backporting #145 to v1.0.0.rc1 following [the first procedure here][1].

[1]: https://github.com/opencontainers/ocitools/pull/140#issuecomment-234626841