### PR TITLE
generate: remove unuseful default value for output

### DIFF
--- a/cmd/ocitools/generate.go
+++ b/cmd/ocitools/generate.go
@@ -10,7 +10,7 @@ import (
 )
 
 var generateFlags = []cli.Flag{
-	cli.StringFlag{Name: "output", Value: "output", Usage: "output file (defaults to stdout)"},
+	cli.StringFlag{Name: "output", Usage: "output file (defaults to stdout)"},
 	cli.StringFlag{Name: "rootfs", Value: "rootfs", Usage: "path to the rootfs"},
 	cli.BoolFlag{Name: "read-only", Usage: "make the container's rootfs read-only"},
 	cli.BoolFlag{Name: "privileged", Usage: "enabled privileged container settings"},


### PR DESCRIPTION
Backporting #146 to v1.0.0.rc1 following [the first procedure here][1].

[1]: https://github.com/opencontainers/ocitools/pull/140#issuecomment-234626841