### PR TITLE
Godeps: Roll runtime-spec back to v1.0.0-rc1

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -15,8 +15,8 @@
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runtime-spec/specs-go",
-			"Comment": "v1.0.0-rc1-15-g6de52a7",
-			"Rev": "6de52a7d39c52a1e287182d0b4e6c03068236639"
+			"Comment": "v1.0.0-rc1",
+			"Rev": "06479209bdc0d4135911688c18157bd39bd99c22"
 		},
 		{
 			"ImportPath": "github.com/syndtr/gocapability/capability",

--- a/Godeps/_workspace/src/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/Godeps/_workspace/src/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -53,15 +53,15 @@ type Process struct {
 	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
 }
 
-// User specifies Linux/Solaris specific user and group information for the container's
+// User specifies Linux specific user and group information for the container's
 // main process.
 type User struct {
 	// UID is the user id. (this field is platform dependent)
-	UID uint32 `json:"uid" platform:"linux,solaris"`
+	UID uint32 `json:"uid" platform:"linux"`
 	// GID is the group id. (this field is platform dependent)
-	GID uint32 `json:"gid" platform:"linux,solaris"`
+	GID uint32 `json:"gid" platform:"linux"`
 	// AdditionalGids are additional group ids set for the container's process. (this field is platform dependent)
-	AdditionalGids []uint32 `json:"additionalGids,omitempty" platform:"linux,solaris"`
+	AdditionalGids []uint32 `json:"additionalGids,omitempty" platform:"linux"`
 }
 
 // Root contains information about the container's root filesystem on the host.

--- a/Godeps/_workspace/src/github.com/opencontainers/runtime-spec/specs-go/version.go
+++ b/Godeps/_workspace/src/github.com/opencontainers/runtime-spec/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc1-dev"
+	VersionDev = "-rc1"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
The commit reference that landed in 2d0dbcf0 (Update runtime-spec dependency to v1.0.0-rc1, 2016-06-14, #110) was a few commits after the tag, but the v1.0.0.rc1 branch is aiming for compatibility with the tagged release (e.g. no -dev suffix on the generated version).

I am not very familiar with godep, so I stubled around for a bit to make this change and don't have a set of copy/paste steps to share here :p.