### PR TITLE
Modify generate API

### DIFF
--- a/cmd/ocitools/generate.go
+++ b/cmd/ocitools/generate.go
@@ -124,9 +124,7 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 			if len(pair) != 2 {
 				return fmt.Errorf("incorrectly specified annotation: %s", s)
 			}
-			if err := g.AddAnnotation(pair[0], pair[1]); err != nil {
-				return err
-			}
+			g.AddAnnotation(pair[0], pair[1])
 		}
 	}
 
@@ -254,9 +252,7 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 			if err != nil {
 				return err
 			}
-			if err := g.AddTmpfsMount(dest, options); err != nil {
-				return err
-			}
+			g.AddTmpfsMount(dest, options)
 		}
 	}
 
@@ -272,10 +268,7 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 			if err != nil {
 				return err
 			}
-
-			if err := g.AddBindMount(source, dest, options); err != nil {
-				return err
-			}
+			g.AddBindMount(source, dest, options)
 		}
 	}
 
@@ -283,9 +276,7 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 		preStartHooks := context.StringSlice("prestart")
 		for _, hook := range preStartHooks {
 			path, args := parseHook(hook)
-			if err := g.AddPreStartHook(path, args); err != nil {
-				return err
-			}
+			g.AddPreStartHook(path, args)
 		}
 	}
 
@@ -293,9 +284,7 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 		postStopHooks := context.StringSlice("poststop")
 		for _, hook := range postStopHooks {
 			path, args := parseHook(hook)
-			if err := g.AddPostStopHook(path, args); err != nil {
-				return err
-			}
+			g.AddPostStopHook(path, args)
 		}
 	}
 
@@ -303,9 +292,7 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 		postStartHooks := context.StringSlice("poststart")
 		for _, hook := range postStartHooks {
 			path, args := parseHook(hook)
-			if err := g.AddPostStartHook(path, args); err != nil {
-				return err
-			}
+			g.AddPostStartHook(path, args)
 		}
 	}
 
@@ -322,9 +309,7 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 			return err
 		}
 
-		if err := g.AddLinuxUIDMapping(hid, cid, size); err != nil {
-			return err
-		}
+		g.AddLinuxUIDMapping(hid, cid, size)
 	}
 
 	for _, gidMap := range gidMaps {
@@ -333,9 +318,7 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 			return err
 		}
 
-		if err := g.AddLinuxGIDMapping(hid, cid, size); err != nil {
-			return err
-		}
+		g.AddLinuxGIDMapping(hid, cid, size)
 	}
 
 	var sd string

--- a/cmd/ocitools/generate.go
+++ b/cmd/ocitools/generate.go
@@ -174,7 +174,11 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 	if context.IsSet("groups") {
 		groups := context.StringSlice("groups")
 		for _, group := range groups {
-			g.AddProcessAdditionalGid(group)
+			groupID, err := strconv.Atoi(group)
+			if err != nil {
+				return err
+			}
+			g.AddProcessAdditionalGid(uint32(groupID))
 		}
 	}
 

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -334,20 +334,14 @@ func (g *Generator) ClearProcessAdditionalGids() {
 }
 
 // AddProcessAdditionalGid adds an additional gid into g.spec.Process.AdditionalGids.
-func (g *Generator) AddProcessAdditionalGid(gid string) error {
-	groupID, err := strconv.Atoi(gid)
-	if err != nil {
-		return err
-	}
-
+func (g *Generator) AddProcessAdditionalGid(gid uint32) {
 	g.initSpec()
 	for _, group := range g.spec.Process.User.AdditionalGids {
-		if group == uint32(groupID) {
-			return nil
+		if group == gid {
+			return
 		}
 	}
-	g.spec.Process.User.AdditionalGids = append(g.spec.Process.User.AdditionalGids, uint32(groupID))
-	return nil
+	g.spec.Process.User.AdditionalGids = append(g.spec.Process.User.AdditionalGids, gid)
 }
 
 // SetProcessSelinuxLabel sets g.spec.Process.SelinuxLabel.

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -244,10 +244,9 @@ func (g *Generator) ClearAnnotations() {
 }
 
 // AddAnnotation adds an annotation into g.spec.Annotations.
-func (g *Generator) AddAnnotation(key, value string) error {
+func (g *Generator) AddAnnotation(key, value string) {
 	g.initSpecAnnotations()
 	g.spec.Annotations[key] = value
-	return nil
 }
 
 // RemoveAnnotation remove an annotation from g.spec.Annotations.
@@ -456,10 +455,9 @@ func (g *Generator) ClearLinuxSysctl() {
 }
 
 // AddLinuxSysctl adds a new sysctl config into g.spec.Linux.Sysctl.
-func (g *Generator) AddLinuxSysctl(key, value string) error {
+func (g *Generator) AddLinuxSysctl(key, value string) {
 	g.initSpecLinuxSysctl()
 	g.spec.Linux.Sysctl[key] = value
-	return nil
 }
 
 // RemoveLinuxSysctl removes a sysctl config from g.spec.Linux.Sysctl.
@@ -751,7 +749,7 @@ func (g *Generator) ClearLinuxUIDMappings() {
 }
 
 // AddLinuxUIDMapping adds uidMap into g.spec.Linux.UIDMappings.
-func (g *Generator) AddLinuxUIDMapping(hid, cid, size uint32) error {
+func (g *Generator) AddLinuxUIDMapping(hid, cid, size uint32) {
 	idMapping := rspec.IDMapping{
 		HostID:      hid,
 		ContainerID: cid,
@@ -760,7 +758,6 @@ func (g *Generator) AddLinuxUIDMapping(hid, cid, size uint32) error {
 
 	g.initSpecLinux()
 	g.spec.Linux.UIDMappings = append(g.spec.Linux.UIDMappings, idMapping)
-	return nil
 }
 
 // ClearLinuxGIDMappings clear g.spec.Linux.GIDMappings.
@@ -772,7 +769,7 @@ func (g *Generator) ClearLinuxGIDMappings() {
 }
 
 // AddLinuxGIDMapping adds gidMap into g.spec.Linux.GIDMappings.
-func (g *Generator) AddLinuxGIDMapping(hid, cid, size uint32) error {
+func (g *Generator) AddLinuxGIDMapping(hid, cid, size uint32) {
 	idMapping := rspec.IDMapping{
 		HostID:      hid,
 		ContainerID: cid,
@@ -781,7 +778,6 @@ func (g *Generator) AddLinuxGIDMapping(hid, cid, size uint32) error {
 
 	g.initSpecLinux()
 	g.spec.Linux.GIDMappings = append(g.spec.Linux.GIDMappings, idMapping)
-	return nil
 }
 
 // SetLinuxRootPropagation sets g.spec.Linux.RootfsPropagation.
@@ -811,11 +807,10 @@ func (g *Generator) ClearPreStartHooks() {
 }
 
 // AddPreStartHook add a prestart hook into g.spec.Hooks.Prestart.
-func (g *Generator) AddPreStartHook(path string, args []string) error {
+func (g *Generator) AddPreStartHook(path string, args []string) {
 	g.initSpec()
 	hook := rspec.Hook{Path: path, Args: args}
 	g.spec.Hooks.Prestart = append(g.spec.Hooks.Prestart, hook)
-	return nil
 }
 
 // ClearPostStopHooks clear g.spec.Hooks.Poststop.
@@ -827,11 +822,10 @@ func (g *Generator) ClearPostStopHooks() {
 }
 
 // AddPostStopHook adds a poststop hook into g.spec.Hooks.Poststop.
-func (g *Generator) AddPostStopHook(path string, args []string) error {
+func (g *Generator) AddPostStopHook(path string, args []string) {
 	g.initSpec()
 	hook := rspec.Hook{Path: path, Args: args}
 	g.spec.Hooks.Poststop = append(g.spec.Hooks.Poststop, hook)
-	return nil
 }
 
 // ClearPostStartHooks clear g.spec.Hooks.Poststart.
@@ -843,15 +837,14 @@ func (g *Generator) ClearPostStartHooks() {
 }
 
 // AddPostStartHook adds a poststart hook into g.spec.Hooks.Poststart.
-func (g *Generator) AddPostStartHook(path string, args []string) error {
+func (g *Generator) AddPostStartHook(path string, args []string) {
 	g.initSpec()
 	hook := rspec.Hook{Path: path, Args: args}
 	g.spec.Hooks.Poststart = append(g.spec.Hooks.Poststart, hook)
-	return nil
 }
 
 // AddTmpfsMount adds a tmpfs mount into g.spec.Mounts.
-func (g *Generator) AddTmpfsMount(dest string, options []string) error {
+func (g *Generator) AddTmpfsMount(dest string, options []string) {
 	mnt := rspec.Mount{
 		Destination: dest,
 		Type:        "tmpfs",
@@ -861,7 +854,6 @@ func (g *Generator) AddTmpfsMount(dest string, options []string) error {
 
 	g.initSpec()
 	g.spec.Mounts = append(g.spec.Mounts, mnt)
-	return nil
 }
 
 // AddCgroupsMount adds a cgroup mount into g.spec.Mounts.
@@ -888,7 +880,7 @@ func (g *Generator) AddCgroupsMount(mountCgroupOption string) error {
 }
 
 // AddBindMount adds a bind mount into g.spec.Mounts.
-func (g *Generator) AddBindMount(source, dest, options string) error {
+func (g *Generator) AddBindMount(source, dest, options string) {
 	if options == "" {
 		options = "ro"
 	}
@@ -903,7 +895,6 @@ func (g *Generator) AddBindMount(source, dest, options string) error {
 	}
 	g.initSpec()
 	g.spec.Mounts = append(g.spec.Mounts, mnt)
-	return nil
 }
 
 // SetupPrivileged sets up the priviledge-related fields inside g.spec.


### PR DESCRIPTION
This PR tries to make the generate API easier to use.  For example, instead of feeding a whole string to `AddAnnotation`, the new API allows the user to feed a key and a value to `AddAnnotation`.

Note: This PR does not touch any seccomp-relative function to avoid conflicts with Grant's work. 
Signed-off-by: Haiyan Meng <hmeng@redhat.com>