### PR TITLE
[1.0.0.rc1] generate: fix mount-cgroups bug

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -851,6 +851,7 @@ func (g *Generator) AddCgroupsMount(mountCgroupOption string) error {
 	switch mountCgroupOption {
 	case "ro":
 	case "rw":
+		break
 	case "no":
 		return nil
 	default:


### PR DESCRIPTION
Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>

Backported to v1.0.0.rc1 from c4fb2c0 #156 (cherry-pick applied
cleanly).

Signed-off-by: W. Trevor King <wking@tremily.us>