### PR TITLE
change start to run 

### DIFF
--- a/test_runtime.sh
+++ b/test_runtime.sh
@@ -77,9 +77,9 @@ trap cleanup EXIT
 tar -xf  rootfs.tar.gz -C ${TESTDIR}
 cp runtimetest ${TESTDIR}
 
-ocitools generate --output "${TESTDIR}/config.json" "${TEST_ARGS[@]}" --rootfs '.'
+ocitools generate --tty --output "${TESTDIR}/config.json" "${TEST_ARGS[@]}" --rootfs '.'
 
-TESTCMD="${RUNTIME} start $(uuidgen)"
+TESTCMD="${RUNTIME} run $(uuidgen)"
 pushd $TESTDIR > /dev/null
 if ! ${TESTCMD}; then
 	error "Runtime ${RUNTIME} failed validation"


### PR DESCRIPTION
I Follow the instructions(README.md),  and "./test_runtime.sh -r docker-runc" execute failed. So I have this modify.
*    runc start failed if it has no runc create ,so change start to run (create+start), it will avoid "**/state.json: no such file or directory" error.
*    add --tty to command ,the generated config.json will has"terminal: true",  it will avoid the "/dev/console not found" error.
then I can see the validation.
```
root@ubuntu:****opencontainers/ocitools# ./test_runtime.sh -r docker-runc -l debug
-----------------------------------------------------------------------------------
VALIDATING RUNTIME: docker-runb
-----------------------------------------------------------------------------------
DEBU[0000] validating root filesystem                   
DEBU[0000] validating container process                 
DEBU[0000] validating capabilities                      
DEBU[0000] validating hostname                          
DEBU[0000] validating rlimits                           
DEBU[0000] validating mounts exist                      
DEBU[0000] validating linux default filesystem          
DEBU[0000] validating linux default devices             
DEBU[0000] validating sysctls                           
DEBU[0000] validating maskedPaths                       
DEBU[0000] validating readonlyPaths                     
Runtime docker-runb passed validation
```


Signed-off-by: Shukui Yang <yangshukui@huawei.com>